### PR TITLE
Add 'mini' version of normalize meant for component Shadow DOM roots

### DIFF
--- a/_generic.normalize-mini.scss
+++ b/_generic.normalize-mini.scss
@@ -1,0 +1,27 @@
+/**
+ * A tiny subset of the Predix UI normalize Sass module that is meant for use
+ * when building components that don't need a ton of resets. These styles are
+ * all scope to `:host` so they will work inside the Shadow DOM of a component
+ * that imports them.
+ *
+ * Only does the following
+ * 1. Sets the component text color based on $inuit-base-text-color.
+ * 2. Sets the component text line-height based on $inuit-base-line-height and
+ *    $inuit-base-font-size.
+ * 3. Prevent certain mobile browsers from automatically zooming fonts.
+ * 4. Fonts on OSX will look more consistent with other systems that do not
+ *    render text using sub-pixel anti-aliasing.
+ *
+ * Some rules based on normalize.css v3.0.2 | MIT License | git.io/normalize
+ */
+
+// Needed to define required $inuit-base-* Sass variables
+@import "px-defaults-design/_settings.defaults.scss";
+
+:host {
+  color: $inuit-base-text-color; /* [1] */
+  line-height: $inuit-base-line-height / $inuit-base-font-size; /* [2] */
+  text-size-adjust: 100%; /* [3] */
+  -moz-osx-font-smoothing: grayscale; /* [4] */
+  -webkit-font-smoothing: antialiased; /* [4] */
+}


### PR DESCRIPTION
Adds a `_generic.normalize-mini.scss` file that includes the minimum normalize resets necessary to style a component. Using this will allow components to prevent bloat by not grabbing all the normalize styles for tags the component won't implement (e.g. h1 or hr).

@mdwragg @Menkhaus-ge Could you review? Want to make sure (1) we should include this with normalize and (2) this is actually the minimal amount of stuff a component would need.